### PR TITLE
Update for bignum version 0.11.0 with nan v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "readmeFilename": "README.md",
 
   "dependencies": {
-    "bignum": "0.10.2"
+    "bignum": "0.11.0"
   },
 
   "devDependencies": {


### PR DESCRIPTION
Updated bignum to 0.11.0 for node v4.0 compatibility
