### PR TITLE
Bump bignum to ~0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "readmeFilename": "README.md",
 
   "dependencies": {
-    "bignum": "0.11.0"
+    "bignum": "^0.12.0"
   },
 
   "devDependencies": {


### PR DESCRIPTION
This will fix the issue of missing arm64 which is fixed in bignum 0.12.1 https://github.com/justmoon/node-bignum/pull/77
